### PR TITLE
Improve README search positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Models may propose actions. CapFence decides whether those actions are allowed b
 
 Use CapFence when agents can touch shell commands, databases, filesystems, payment APIs, internal APIs, SaaS admin tools, or MCP servers.
 
+Use CapFence for AI agent authorization, agent tool-call authorization, MCP tool authorization, pre-execution policy checks, and security controls for agents that can cause real-world side effects.
+
 <p align="center">
   <a href="https://pypi.org/project/capfence/"><img src="https://img.shields.io/pypi/v/capfence?color=blue" alt="PyPI version"></a>
   <a href="https://pypi.org/project/capfence/"><img src="https://img.shields.io/pypi/pyversions/capfence" alt="Python versions"></a>
@@ -32,11 +34,35 @@ rm -rf /var/lib/postgresql
 CapFence returns:
 
 ```txt
-Decision: DENY
+Decision: deny
 Reason: destructive production filesystem operation
 Tool invoked: false
 Replay: capfence replay audit_sample.jsonl --policy policy.yaml
 ```
+
+The command is blocked before the process is spawned.
+
+## Approval Required Action
+
+A support agent proposes:
+
+```python
+refund_customer(customer_id="cus_123", amount=5000, reason="billing issue")
+```
+
+The agent may be allowed to request refunds, but not every refund should execute automatically.
+
+CapFence can evaluate the actor, tool, action, resource, amount, environment, and context before execution.
+
+Example policy outcome:
+
+```txt
+Decision: require_approval
+Reason: refund amount exceeds automatic approval threshold
+Tool invoked: false
+```
+
+CapFence does not only ask whether an agent can call a tool. It asks whether this specific action, with these arguments, should be allowed now.
 
 ## Install
 
@@ -81,7 +107,7 @@ if not verdict.authorized:
 Expected result:
 
 ```text
-decision: DENY
+decision: deny
 reason: policy_deny
 tool_invoked: false
 ```
@@ -131,6 +157,31 @@ The operational question is:
 
 CapFence is built for that boundary.
 
+## What CapFence Checks
+
+CapFence authorization decisions can include:
+
+- actor: which agent or user is requesting the action
+- capability: what permission boundary is being exercised
+- tool: which tool, API, MCP server, or executor is being called
+- action: what operation is being performed
+- resource: what object, system, or environment is affected
+- payload: what arguments or parameters are being passed
+- environment: development, staging, or production
+- policy: which allow, deny, or approval rule applies
+- audit state: what decision was made and how it can be replayed
+
+This makes CapFence different from simple tool allowlists. The risk is often not only the tool name. The risk is the arguments and context of the tool call.
+
+For example:
+
+```txt
+refund_customer(amount=50)      -> allow
+refund_customer(amount=5000)    -> require_approval or deny
+```
+
+Both calls use the same tool. They should not necessarily receive the same authorization decision.
+
 ## How CapFence Is Different
 
 | Category | What it controls | Weakness | CapFence difference |
@@ -144,11 +195,17 @@ CapFence is built for that boundary.
 
 ## Use CapFence For
 
-- `shell.exec` boundaries before a process is spawned.
-- MCP tool authorization before the upstream server receives a request.
-- Filesystem scope enforcement before secrets or repo-external paths are read.
-- Database write and schema-change controls before queries execute.
-- Payment or API action thresholds before external state changes.
+- AI agent authorization before tool execution
+- agent tool-call authorization for risky actions
+- pre-execution authorization for AI agents
+- MCP tool authorization before upstream servers receive requests
+- human approval workflows for sensitive agent actions
+- tool-call policy enforcement across agents and executors
+- shell command authorization before a process is spawned
+- filesystem scope enforcement before secrets or repo-external paths are read
+- database write and schema-change controls before queries execute
+- payment, refund, CRM, email, SaaS admin, and internal API thresholds before external state changes
+- audit replay for policy decisions and blocked actions
 
 ## CapFence Is Not
 
@@ -158,6 +215,11 @@ CapFence is built for that boundary.
 - A prompt guardrail.
 - An AI judge.
 - A compliance dashboard.
+- A replacement for downstream IAM, sandboxing, network controls, or database permissions.
+
+CapFence focuses on one specific boundary:
+
+> Should this agent action be allowed before execution?
 
 ## Core Docs
 


### PR DESCRIPTION
## Description

Updates the CapFence README with clearer search-friendly positioning while preserving the existing product framing and pre-1.0 maturity disclosure.

This PR adds stronger language around AI agent authorization, agent tool-call authorization, MCP tool authorization, pre-execution policy checks, approval-required actions, and audit replay. It also adds a “What CapFence Checks” section and expands the use-case list so the README better matches how users may search for the project.

Fixes # 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Security hardening

## Test coverage

- [ ] I have added tests for my changes
- [ ] I have run `pytest tests/ -q` and all tests pass
- [ ] I have run `mypy --strict capfence/` and there are no new errors
- [ ] I have run `ruff check capfence/ tests/` and there are no new errors

Validation run:

- [x] `python3 -m pytest tests/test_redesign_primitives.py::TestActionRuntime -q`

## Checklist

- [x] My code follows the coding standards in CONTRIBUTING.md
- [x] I have updated the documentation (README, docs/, or inline docstrings) if my change affects user-facing behavior
- [ ] I have added an entry to CHANGELOG.md under [Unreleased]
- [x] I have verified that my change does not introduce new security vulnerabilities (see SECURITY.md for scope)
- [x] I have checked that my change does not claim features that do not exist in the codebase

## Breaking changes

- [ ] This PR introduces a breaking change
- [ ] If checked above, describe the breaking change and migration path:

No breaking changes.